### PR TITLE
[WIP] Support parallel computation under Windows for KFOCI and KPCRKHS_VS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,6 @@ Encoding: UTF-8
 URL: https://www.jmlr.org/papers/v23/21-493.html,
         https://arxiv.org/abs/2012.14804
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Depends: R (>= 4.0.0), data.table, kernlab
 Imports: RANN, proxy, parallel, mlpack

--- a/R/KPC.R
+++ b/R/KPC.R
@@ -363,7 +363,15 @@ KFOCI <- function(Y, X, k = kernlab::rbfdot(1/(2*stats::median(stats::dist(Y))^2
   estimateQFixedY <- function(id){
     return(TnKnn(Y, X[, id],k,Knn))
   }
-  seq_Q = parallel::mclapply(seq(1, p), estimateQFixedY, mc.cores = numCores)
+  if (.Platform$OS.type == "windows") {
+    cl <- parallel::makeCluster(numCores)
+    parallel::clusterEvalQ(cl, library(KPC))
+    parallel::clusterExport(cl, c("Y", "X", "k", "Knn", "estimateQFixedY"), 
+                            envir = environment())
+    seq_Q = parallel::parLapply(cl, seq(1, p), estimateQFixedY)
+  } else {
+    seq_Q = parallel::mclapply(seq(1, p), estimateQFixedY, mc.cores = numCores)
+  }
   seq_Q = unlist(seq_Q)
 
 
@@ -388,7 +396,13 @@ KFOCI <- function(Y, X, k = kernlab::rbfdot(1/(2*stats::median(stats::dist(Y))^2
     if (length(index_left) == 1) {
       seq_Q = estimateQFixedYandSubX(index_left[1])
     } else {
-      seq_Q = parallel::mclapply(index_left, estimateQFixedYandSubX, mc.cores = numCores)
+      if (.Platform$OS.type == "windows") {
+        parallel::clusterExport(cl, c("index_select", "count", "estimateQFixedYandSubX"), 
+                                envir = environment())
+        seq_Q = parallel::parLapply(cl, index_left, estimateQFixedYandSubX)
+      } else {
+        seq_Q = parallel::mclapply(index_left, estimateQFixedYandSubX, mc.cores = numCores)
+      }
       seq_Q = unlist(seq_Q)
     }
     Q[count + 1] = max(seq_Q)
@@ -398,6 +412,8 @@ KFOCI <- function(Y, X, k = kernlab::rbfdot(1/(2*stats::median(stats::dist(Y))^2
     count = count + 1
     if (verbose) print(paste("Variable",index_select[count],"is selected"))
   }
+  if (.Platform$OS.type == "windows")
+    parallel::stopCluster(cl) 
 
   return(index_select[1:count])
 }
@@ -466,7 +482,20 @@ KPCRKHS_VS <- function(Y, X, num_features, ky = kernlab::rbfdot(1/(2*stats::medi
   estimateQFixedY <- function(id){
     return(KPCRKHS_numerator(Y,NULL,X[,id],ky,NULL,kS(X,id),eps,appro,tol))
   }
-  seq_Q = parallel::mclapply(seq(1, p), estimateQFixedY, mc.cores = numCores)
+  if (.Platform$OS.type == "windows") {
+    cl <- parallel::makeCluster(numCores)
+    parallel::clusterEvalQ(cl, library(KPC))
+    parallel::clusterExport(cl, c("Y", "X", "ky", "kS", "eps", "appro", "tol", 
+                                  "KPCRKHS_numerator", "estimateQFixedY"), 
+                            envir = environment())
+    # adding the non-exported function KPCRKHS_numerator seems to work,
+    # although https://stackoverflow.com/questions/38836341/parallelclusterexport-non-exported-library-package-function
+    # suggests that the following call is needed
+    #parallel::clusterCall(cl, assign, "KPCRKHS_numerator", KPCRKHS_numerator, envir = environment())
+    seq_Q = parallel::parLapply(cl, seq(1, p), estimateQFixedY) 
+  } else {
+    seq_Q = parallel::mclapply(seq(1, p), estimateQFixedY, mc.cores = numCores)
+  }
   seq_Q = unlist(seq_Q)
 
 
@@ -490,7 +519,13 @@ KPCRKHS_VS <- function(Y, X, num_features, ky = kernlab::rbfdot(1/(2*stats::medi
     if (length(index_left) == 1) {
       seq_Q = estimateQFixedYandSubX(index_left[1])
     } else {
-      seq_Q = parallel::mclapply(index_left, estimateQFixedYandSubX, mc.cores = numCores)
+      if (.Platform$OS.type == "windows") {
+        parallel::clusterExport(cl, c("index_select", "count", "estimateQFixedYandSubX"), 
+                                envir = environment())
+        seq_Q = parallel::parLapply(cl, index_left, estimateQFixedYandSubX)
+      } else {
+        seq_Q = parallel::mclapply(index_left, estimateQFixedYandSubX, mc.cores = numCores)
+      }
       seq_Q = unlist(seq_Q)
     }
     Q[count + 1] = max(seq_Q)
@@ -499,6 +534,8 @@ KPCRKHS_VS <- function(Y, X, num_features, ky = kernlab::rbfdot(1/(2*stats::medi
     count = count + 1
     if (verbose) print(paste("Variable",index_select[count],"is selected"))
   }
+  if (.Platform$OS.type == "windows")
+    parallel::stopCluster(cl)
 
   return(index_select[1:count])
 }

--- a/R/KPC.R
+++ b/R/KPC.R
@@ -488,10 +488,6 @@ KPCRKHS_VS <- function(Y, X, num_features, ky = kernlab::rbfdot(1/(2*stats::medi
     parallel::clusterExport(cl, c("Y", "X", "ky", "kS", "eps", "appro", "tol", 
                                   "KPCRKHS_numerator", "estimateQFixedY"), 
                             envir = environment())
-    # adding the non-exported function KPCRKHS_numerator seems to work,
-    # although https://stackoverflow.com/questions/38836341/parallelclusterexport-non-exported-library-package-function
-    # suggests that the following call is needed
-    #parallel::clusterCall(cl, assign, "KPCRKHS_numerator", KPCRKHS_numerator, envir = environment())
     seq_Q = parallel::parLapply(cl, seq(1, p), estimateQFixedY) 
   } else {
     seq_Q = parallel::mclapply(seq(1, p), estimateQFixedY, mc.cores = numCores)


### PR DESCRIPTION
As mentioned via mail, I now took the initiative to start working on the parallel computation under Windows; nevertheless, please let me know if you are in principle interested in such a change. Currently, this is based on the parallel package only. I included a simple if-else statement that will either use parLapply or mclapply, depending on the OS. It might be nicer to completely move towards another package that works regardless of the OS (e.g. using the future framework), but that would require other dependencies.
